### PR TITLE
fix enb make from stylus

### DIFF
--- a/common.blocks/typo/typo.styl
+++ b/common.blocks/typo/typo.styl
@@ -1,7 +1,5 @@
-for $h in 1..4
-{
-    h{$h}
-    {
+for $h in 1..4 {
+    h{$h} {
         font-size:     $rem_font_size * lookup('$h' + $h + '_scale');
         line-height:   $rem_line_height * lookup('$h' + $h + '_scale');
         margin-top:    2 * $rem_font_size;
@@ -9,8 +7,7 @@ for $h in 1..4
     }
 }
 
-p
-{
+p {
     margin-top:    $rem_line_height;
     margin-bottom: $rem_line_height;
     font-size:     $rem_font_size;


### PR DESCRIPTION
16:41:11.689 - build failed
TypeError: /Users/uradvd85/Documents/www/bem.blog.test/blog.bem.views/libs/bem-typography/common.blocks/typo/typo.styl:19
   15|     margin-bottom: $rem_line_height;
   16|     font-size:     $rem_font_size;
   17|     line-height:   $rem_line_height;
   18| }

> 19| 

Cannot read property 'block' of undefined

```
at Group.__defineSetter__.i [as block] (/Users/uradvd85/Documents/www/bem.blog.test/blog.bem.views/node_modules/enb-stylus/node_modules/stylus/lib/nodes/group.js:48:23)
at Group.clone (/Users/uradvd85/Documents/www/bem.blog.test/blog.bem.views/node_modules/enb-stylus/node_modules/stylus/lib/nodes/group.js:89:21)
at /Users/uradvd85/Documents/www/bem.blog.test/blog.bem.views/node_modules/enb-stylus/node_modules/stylus/lib/nodes/block.js:92:21
at Array.forEach (native)
at Block.clone (/Users/uradvd85/Documents/www/bem.blog.test/blog.bem.views/node_modules/enb-stylus/node_modules/stylus/lib/nodes/block.js:91:14)
at Each.clone (/Users/uradvd85/Documents/www/bem.blog.test/blog.bem.views/node_modules/enb-stylus/node_modules/stylus/lib/nodes/each.js:50:28)
at /Users/uradvd85/Documents/www/bem.blog.test/blog.bem.views/node_modules/enb-stylus/node_modules/stylus/lib/nodes/block.js:92:21
at Array.forEach (native)
at Block.clone (/Users/uradvd85/Documents/www/bem.blog.test/blog.bem.views/node_modules/enb-stylus/node_modules/stylus/lib/nodes/block.js:91:14)
at MemoryCache.set (/Users/uradvd85/Documents/www/bem.blog.test/blog.bem.views/node_modules/enb-stylus/node_modules/stylus/lib/cache/memory.js:20:28)
```
